### PR TITLE
Add action to copy email addresses to kill ring.

### DIFF
--- a/helm-mu.el
+++ b/helm-mu.el
@@ -374,7 +374,7 @@ address.  The name column has a predefined width."
   (let* ((cand (split-string candidate "\t"))
          (name (cadr cand))
          (address (car cand)))
-    (concat name " <" address ">")))
+    (concat "\"" name "\"" " <" address ">")))
 
 
 (defun helm-mu-open-headers-view ()

--- a/helm-mu.el
+++ b/helm-mu.el
@@ -210,7 +210,8 @@ See `helm-mu-get-search-pattern'"
     :filtered-candidate-transformer #'helm-mu-contacts-transformer
     :fuzzy-match nil
     :action '(("Compose email addressed to this contact" . helm-mu-compose-mail)
-              ("Get the emails from/to given contacts" . helm-mu-action-get-contact-emails))))
+              ("Get the emails from/to given contacts" . helm-mu-action-get-contact-emails)
+              ("Copy address to clipboard" . helm-mu-action-kill-address))))
 
 
 
@@ -414,6 +415,13 @@ address.  The name column has a predefined width."
                                                            " OR ")
                                                 ")")))
     (helm-mu)))
+
+(defun helm-mu-action-kill-address (candidate)
+  "Make the addresses in CANDIDATE the latest entry in the kill ring."
+  (let ((addresses (mapconcat 'helm-mu-format-contact
+                              (helm-marked-candidates) ", ")))
+    (kill-new addresses)
+    (message (concat  "Copied: " addresses))))
 
 (defun helm-mu-persistent-action (candidate)
   (save-selected-window


### PR DESCRIPTION
Admittedly, this scratches my own itch but I _think_ it's handy.

Also fixes an issue I had with the formatting of contacts with commas in their names.
